### PR TITLE
ci: 添加自动发布工作流

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'data/**'  # 当数据文件变更时触发
+  workflow_dispatch:  # 允许手动触发
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r scripts/requirements.txt
+        
+    - name: Generate exports
+      run: |
+        python scripts/export.py --format json
+        python scripts/export.py --format csv
+        
+    - name: Get current date
+      id: date
+      run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: 数据更新 ${{ steps.date.outputs.DATE }}
+        tag_name: release-${{ steps.date.outputs.DATE }}
+        body: |
+          ## 数据更新 (${{ steps.date.outputs.DATE }})
+          
+          ### 下载
+          - [JSON格式](drugs.json)
+          - [CSV格式](drugs.csv)
+          
+          ### 说明
+          - 自动从main分支生成
+          - 包含所有最新数据
+          - 格式已经过验证
+        files: |
+          exports/drugs.json
+          exports/drugs.csv
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@
 
 ## 快速开始
 
+### 下载数据
+
+- [最新版本](https://github.com/dongzhenye/yuanyanyao/releases/latest)
+- [历史版本](https://github.com/dongzhenye/yuanyanyao/releases)
+
+支持的格式：
+
+- JSON（完整数据，推荐）
+- CSV（扁平格式，Excel友好）
+
+### 本地克隆
+
 ```bash
 git clone https://github.com/dongzhenye/yuanyanyao.git
 cd yuanyanyao/data


### PR DESCRIPTION
添加自动发布功能，方便用户下载最新数据。

### 功能说明

1. **自动发布工作流**
   - 监听data目录变更自动触发
   - 支持手动触发发布
   - 生成JSON和CSV格式数据
   - 创建带版本号的Release

2. **用户下载入口**
   - 在README中添加下载链接
   - 支持最新版本和历史版本
   - 提供多种数据格式选择

### 触发条件

- 当data目录文件变更时自动触发
- 通过Actions页面手动触发